### PR TITLE
Observability: add the result of /fib as an attribute

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,7 @@ app.get("/fib", async (req, res) => {
       minusTwoReturn.fibonacciNumber);
   }
 
+  span.setAttribute("app.seqofnum.result.fibonacciNumber", returnValue);
   const returnObject = { fibonacciNumber: returnValue, index: index }
   res.send(JSON.stringify(returnObject));
 });


### PR DESCRIPTION
## What is the goal of this change?

learn whether it's valid to cache the result of a call to /fib

This change adds result.fibonacciNumber as a span attribute.
If this turns out to be the same per index parameter, then it is safe to cache.

## How will we know this change worked?

Run a Honeycomb query and group by the result.

Here's the query from local testing: https://ui.honeycomb.io/hello-observability/datasets/dev-hello-observability/result/7HdiwdCyA9T

The result looks like this:
![image](https://user-images.githubusercontent.com/1149737/152889275-b02046e5-dbd1-44ba-84cf-3eb5f3142353.png)

Look, the results spell out the Fibonacci sequence!
